### PR TITLE
Fixed project_id description

### DIFF
--- a/step.yml
+++ b/step.yml
@@ -72,7 +72,7 @@ inputs:
       description: |-
         The Project ID can be found in the Auitify URL. For example:
 
-        - `autify.com/projects/<Project ID>`
+        - `autify.com/projects/{Project ID}`
 
       is_required: true
   - upload_token:


### PR DESCRIPTION
A string with `<>` in the description was recognized as a HTML tag by Bitrise.
Changed it to `{}`.